### PR TITLE
Feature/restic version checks

### DIFF
--- a/backend/restic/restic_test.go
+++ b/backend/restic/restic_test.go
@@ -6,7 +6,6 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 )
 
@@ -57,8 +56,10 @@ func TestResticProgram(t *testing.T) {
 	if err != nil {
 		t.Fatal("failed to resolve restic binary", err)
 	}
-	if len(strings.Split(restic.Version, ".")) != 3 {
-		t.Error("unexpected restic version number")
+	if restic.Version[0] == 0 &&
+		restic.Version[1] == 0 &&
+		restic.Version[2] == 0 {
+		t.Error("failed to parse restic version number")
 	}
 }
 

--- a/frontend/src/components/file-list.ts
+++ b/frontend/src/components/file-list.ts
@@ -83,7 +83,8 @@ export class ResticBrowserFileList extends MobxLitElement {
       .catch((err) => { 
         Notification.show(`Failed to restore file: ${err.message || err}`, {
           position: 'middle',
-          theme: "error"
+          theme: "error",
+          duration: 10000
         });
       });
   }


### PR DESCRIPTION
Show a proper error message when folder dumps are not possible because the installed restic program version is too old (see https://github.com/emuell/restic-browser/issues/22) 