### PR TITLE
Application Arguments

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2886,6 +2886,7 @@ dependencies = [
  "open 5.0.0",
  "serde",
  "serde_json",
+ "shlex",
  "simplelog",
  "tauri",
  "tauri-build",
@@ -3223,6 +3224,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
 
 [[package]]
 name = "signal-hook-registry"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,6 +22,7 @@ simplelog = { version = "^0.12" }
 anyhow = { version = "^1.0" }
 which = { version = "^4.0" }
 open = { version = "^5.0" }
+shlex = { version = "^1.2" }
 
 #tauri
 tauri = { version = "^1.5", features = [ "cli", "api-all"] }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -52,13 +52,14 @@ fn initialize_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>
 
     // get restic from args or find restic in path
     let mut restic_path = "".to_owned();
-    if let Ok(matches) = app.get_cli_matches() {
-        if let Some(arg) = matches.args.get("restic") {
+    match app.get_cli_matches() {
+        Ok(matches) => if let Some(arg) = matches.args.get("restic") {
             restic_path = arg.value.as_str().unwrap_or("").to_string();
             if !restic_path.is_empty() {
                 log::info!("Got restic as arg {}", restic_path);
             }
-        }
+        },
+        Err(err) => log::error!("{}", err.to_string())
     }
     if restic_path.is_empty() {
         if let Ok(restic) = which("restic") {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,7 +1,7 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-use std::{env, fs, path, process};
+use std::{collections::HashMap, env, fs, path, process};
 
 use anyhow::anyhow;
 use simplelog::*;
@@ -84,6 +84,23 @@ fn initialize_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>
         }
     }
 
+    // get default restic location from args or env
+    let mut location;
+    if let Ok(matches) = app.get_cli_matches() {
+        location = Location::new_from_args(
+            matches
+                .args
+                .into_iter()
+                .map(|(k, v)| (k, v.value.as_str().unwrap_or("").to_string()))
+                .collect::<HashMap<_, _>>(),
+        );
+        if location.path.is_empty() {
+            location = Location::new_from_env();
+        }
+    } else {
+        location = Location::new_from_env();
+    }
+
     // create temp dir for previews
     let mut temp_dir = path::Path::new(&env::temp_dir())
         .join(app.package_info().name.clone() + "_" + &process::id().to_string());
@@ -97,7 +114,7 @@ fn initialize_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>
     // create new app state
     app.manage(app::SharedAppState::new(app::AppState::new(
         ResticCommand::new(&restic_path),
-        Location::default(),
+        location,
         temp_dir.to_string_lossy().as_ref(),
     )));
 
@@ -129,7 +146,7 @@ fn show_app(app_window: tauri::Window) -> Result<(), String> {
 
 fn main() {
     // create new app
-    tauri::Builder::default()
+    let app = tauri::Builder::default()
         .setup(initialize_app)
         .on_window_event(|event| {
             if let tauri::WindowEvent::Destroyed = event.event() {
@@ -157,6 +174,28 @@ fn main() {
             app::dump_file_to_temp,
             app::restore_file
         ])
-        .run(tauri::generate_context!())
+        .build(tauri::generate_context!())
         .expect("error while running tauri application");
+
+    // show argument help / version only
+    let mut do_run = true;
+    if let Ok(matches) = app.get_cli_matches() {
+        if let Some(arg) = matches.args.get("help") {
+            print!("{}", arg.value.as_str().unwrap());
+            do_run = false;
+        } else if matches.args.get("version").is_some() {
+            let package = app.config().package.clone();
+            println!(
+                "{} v{}",
+                package.product_name.unwrap_or("Restic Browser".to_string()),
+                package.version.unwrap_or("[Unknown version]".to_string())
+            );
+            do_run = false;
+        }
+    }
+
+    // run the app
+    if do_run {
+        app.run(|_, _| {});
+    }
 }

--- a/src-tauri/src/restic.rs
+++ b/src-tauri/src/restic.rs
@@ -1,4 +1,6 @@
-use std::{collections::HashMap, fs, process::Command};
+use std::{collections::HashMap, env, fs, process::Command};
+
+use shlex::Shlex;
 
 #[cfg(target_os = "windows")]
 use std::os::windows::process::CommandExt;
@@ -12,10 +14,48 @@ pub static RESTIC_EXECTUABLE_NAME: &str = "restic";
 
 // -------------------------------------------------------------------------------------------------
 
+// create new Command and configure it to hide command window on Windows
+fn new_command(program: &str) -> Command {
+    #[allow(unused_mut)]
+    let mut command = Command::new(program);
+    #[cfg(target_os = "windows")]
+    command.creation_flags(0x08000000); // CREATE_NO_WINDOW
+    command
+}
+
+// -------------------------------------------------------------------------------------------------
+
 #[derive(serde::Serialize, serde::Deserialize, Debug, Default, Clone)]
 pub struct EnvValue {
     pub name: String,
     pub value: String,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Debug, Default, Clone)]
+pub struct LocationInfo {
+    pub prefix: String,
+    pub credentials: Vec<String>,
+}
+
+impl LocationInfo {
+    pub fn new(prefix: &str, credentials: Vec<&str>) -> LocationInfo {
+        LocationInfo {
+            prefix: prefix.to_string(),
+            credentials: credentials.iter().map(|c| c.to_string()).collect(),
+        }
+    }
+}
+
+pub fn location_infos() -> Vec<LocationInfo> {
+    vec![
+        LocationInfo::new("bs", vec![]),
+        LocationInfo::new("sftp", vec![]),
+        LocationInfo::new("rest", vec![]),
+        LocationInfo::new("rclone", vec![]),
+        LocationInfo::new("s3", vec!["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"]),
+        LocationInfo::new("b2", vec!["B2_ACCOUNT_ID", "B2_ACCOUNT_KEY"]),
+        LocationInfo::new("azure", vec!["AZURE_ACCOUNT_NAME", "AZURE_ACCOUNT_KEY"]),
+    ]
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, Default, Clone)]
@@ -24,6 +64,95 @@ pub struct Location {
     pub path: String,
     pub credentials: Vec<EnvValue>,
     pub password: String,
+}
+
+impl Location {
+    // create a new Location from the given set of optional restic arguments
+    // see tauri.conf.json for the expected args
+    pub fn new_from_args(args: HashMap<String, String>) -> Location {
+        // filter out empty args
+        let mut args = args.clone();
+        args.retain(|_, v| !v.is_empty());
+        // get repo from file or directly
+        let path = if let Some(repository_file) = args.get("repository-file") {
+            let content = fs::read_to_string(repository_file).unwrap_or(String::new());
+            content.trim_end().to_string()
+        } else {
+            args.get("repository")
+                .or(args.get("repo"))
+                .cloned()
+                .unwrap_or_default()
+        };
+        // get password from file, command or directly
+        let password = if let Some(password_file) = args.get("password-file") {
+            let content = fs::read_to_string(password_file).unwrap_or(String::new());
+            content.trim_end().to_string()
+        } else if let Some(password_command) = args.get("password-command") {
+            let mut program_and_args = Shlex::new(password_command);
+            if let Ok(output) = new_command(&program_and_args.by_ref().nth(0).unwrap_or_default())
+                .args(program_and_args.by_ref().collect::<Vec<_>>())
+                .output()
+            {
+                let stdout = std::str::from_utf8(&output.stdout).unwrap_or("");
+                stdout.trim_end().to_string()
+            } else {
+                "".to_string()
+            }
+        } else {
+            args.get("password")
+                .or(args.get("pass"))
+                .cloned()
+                .unwrap_or_default()
+        };
+        let mut location = Location {
+            path,
+            password,
+            credentials: vec![],
+            prefix: "".to_string(),
+        };
+        if location.path.is_empty() {
+            // skip reading other location info when no repo is present
+            return location;
+        }
+        // set prefix from path and fill in credentials from env
+        location.prefix = "".to_string();
+        for location_info in location_infos() {
+            if location
+                .path
+                .starts_with(&(location_info.prefix.to_string() + ":"))
+            {
+                location.prefix = location_info.prefix.to_string();
+                location.path =
+                    location
+                        .path
+                        .replacen(&(location_info.prefix.to_string() + ":"), "", 1);
+                for credential in location_info.credentials {
+                    location.credentials.push(EnvValue {
+                        name: credential.to_string(),
+                        value: env::var(credential).unwrap_or_default(),
+                    })
+                }
+                break;
+            }
+        }
+        location
+    }
+
+    // create a new Location from restic specific environemnt values.
+    pub fn new_from_env() -> Location {
+        Self::new_from_args(
+            [
+                ("repository", "RESTIC_REPOSITORY"),
+                ("repository-file", "RESTIC_REPOSITORY_FILE"),
+                ("password", "RESTIC_PASSWORD"),
+                ("password-file", "RESTIC_PASSWORD_FILE"),
+                ("password-command", "RESTIC_PASSWORD_COMMAND"),
+            ]
+            .into_iter()
+            .map(|(k, v)| (String::from(k), env::var(v).unwrap_or(String::new())))
+            .collect::<HashMap<_, _>>(),
+        )
+    }
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, Default, Clone)]
@@ -82,7 +211,7 @@ impl ResticCommand {
     // run a restic command for the given location with the given args
     pub fn run(&self, location: Location, args: Vec<&str>) -> Result<String, String> {
         let envs = Self::environment_values(location);
-        let output = Self::new_command(&self.path)
+        let output = new_command(&self.path)
             .envs(envs)
             .args(args.clone())
             .output()
@@ -111,7 +240,7 @@ impl ResticCommand {
         file: fs::File,
     ) -> Result<(), String> {
         let envs = Self::environment_values(location);
-        let output = Self::new_command(&self.path)
+        let output = new_command(&self.path)
             .envs(envs)
             .args(args.clone())
             .stdout(std::process::Stdio::from(file))
@@ -131,20 +260,11 @@ impl ResticCommand {
         }
     }
 
-    // create new Command and configure it to hide command window on Windows
-    fn new_command(program: &str) -> Command {
-        #[allow(unused_mut)]
-        let mut command = Command::new(program);
-        #[cfg(target_os = "windows")]
-        command.creation_flags(0x08000000); // CREATE_NO_WINDOW
-        command
-    }
-
     // run restic command to query its version
     fn query_version(path: &str) -> [i32; 3] {
         // get version from restic binary
         let mut version = [0, 0, 0];
-        match Self::new_command(path).arg("version").output() {
+        match new_command(path).arg("version").output() {
             Ok(output) => {
                 if output.status.success() {
                     // "restic x.y.z some other info"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -90,6 +90,11 @@
           "name": "password-command",
           "takesValue": true,
           "longDescription": "shell command to obtain the repository password from (default: $RESTIC_PASSWORD_COMMAND)"
+        },
+        {
+          "name": "insecure-tls",
+          "takesValue": false,
+          "longDescription": "skip TLS certificate verification when connecting to the repo (insecure)"
         }
       ]
     },

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -28,7 +28,9 @@
     },
     "bundle": {
       "active": true,
-      "targets": ["app"],
+      "targets": [
+        "app"
+      ],
       "category": "DeveloperTool",
       "copyright": "",
       "deb": {
@@ -60,9 +62,34 @@
       "args": [
         {
           "name": "restic",
+          "takesValue": true,
+          "longDescription": "ABS path to the restic executable that should be used. (default: find in $PATH)"
+        },
+        {
+          "name": "repo",
           "short": "r",
           "takesValue": true,
-          "multiple": false
+          "longDescription": "repository to show or restore from (default: $RESTIC_REPOSITORY)"
+        },
+        {
+          "name": "repository-file",
+          "takesValue": true,
+          "longDescription": "file to read the repository location from (default: $RESTIC_REPOSITORY_FILE)"
+        },
+        {
+          "name": "password",
+          "takesValue": true,
+          "longDescription": "password for the repository - NOT RECOMMENDED - USE password-file/command instead. (default: $RESTIC_PASSWORD)"
+        },
+        {
+          "name": "password-file",
+          "takesValue": true,
+          "longDescription": "file to read the repository password from (default: $RESTIC_PASSWORD_FILE)"
+        },
+        {
+          "name": "password-command",
+          "takesValue": true,
+          "longDescription": "shell command to obtain the repository password from (default: $RESTIC_PASSWORD_COMMAND)"
         }
       ]
     },

--- a/src/backend/restic.ts
+++ b/src/backend/restic.ts
@@ -43,13 +43,15 @@ export namespace restic {
     path: string;
     credentials: EnvValue[];
     password: string;
-
+    insecureTls: boolean;
+  
     constructor(source: any = {}) {
       if ('string' === typeof source) source = JSON.parse(source);
       this.prefix = source["prefix"];
       this.path = source["path"];
       this.credentials = this.convertValues(source["credentials"], EnvValue);
       this.password = source["password"];
+      this.insecureTls = source["insecureTls"];
     }
 
     convertValues(a: any, classs: any, asMap: boolean = false): any {

--- a/src/components/location-dialog.ts
+++ b/src/components/location-dialog.ts
@@ -15,6 +15,7 @@ import '@vaadin/dialog';
 import '@vaadin/password-field';
 import '@vaadin/item';
 import '@vaadin/list-box';
+import '@vaadin/checkbox';
 import '@vaadin/button';
 import '@vaadin/select';
 import '@vaadin/notification';
@@ -173,6 +174,16 @@ export class ResticBrowserLocationDialog extends MobxLitElement {
           <vaadin-button theme="primary" style="width: 4rem; margin-top: 35.5px;" 
             @click=${this._readRepositoryPasswordFile}>Read</vaadin-button>
         </vaadin-horizontal-layout>
+
+      ${this._location.type !== "local"
+       ? html`<vaadin-form-item style="margin-top: 10.5px;">
+                <vaadin-checkbox id="checkbox" label="Insecure TSL (skip TLS certificate verifications)"
+                  .checked=${this._location.insecureTls}
+                  @change=${mobx.action((event: CustomEvent) => {
+                    this._location.insecureTls = (event.target as HTMLInputElement).value == "checked";
+                  })}></vaadin-checkbox>`
+        : nothing
+      }
 
       </vaadin-vertical-layout>
     `;

--- a/src/components/location-dialog.ts
+++ b/src/components/location-dialog.ts
@@ -177,7 +177,7 @@ export class ResticBrowserLocationDialog extends MobxLitElement {
 
       ${this._location.type !== "local"
        ? html`<vaadin-form-item style="margin-top: 10.5px;">
-                <vaadin-checkbox id="checkbox" label="Insecure TSL (skip TLS certificate verifications)"
+                <vaadin-checkbox id="checkbox" label="Insecure TLS (skip TLS certificate verifications)"
                   .checked=${this._location.insecureTls}
                   @change=${mobx.action((event: CustomEvent) => {
                     this._location.insecureTls = (event.target as HTMLInputElement).value == "checked";

--- a/src/states/location.ts
+++ b/src/states/location.ts
@@ -46,6 +46,9 @@ export class Location {
   @mobx.observable
   password: string = "";
 
+  @mobx.observable
+  insecureTls: boolean = false;
+
   constructor() {
     mobx.makeObservable(this);
 
@@ -88,6 +91,7 @@ export class Location {
     this.path = "";
     this.credentials = [];
     this.password = "";
+    this.insecureTls = false;
   }
 
   // set location properties from some other Location
@@ -98,6 +102,7 @@ export class Location {
     this.path = other.path;
     this.credentials = Array.from(other.credentials);
     this.password = other.password;
+    this.insecureTls = other.insecureTls;
   }
 
   // set location properties from a restic.Location
@@ -113,6 +118,7 @@ export class Location {
     this.type = locationInfo.type;
     this.path = location.path;
     this.password = location.password;
+    this.insecureTls = location.insecureTls;
     this._setPrefixFromType();
     this._setCredentialsFromType();
     // set all required credentials as well, if they are valid

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
   // env variables
   envPrefix: ['VITE_', 'TAURI_'],
   build: {
+    chunkSizeWarningLimit: 1024,
     // Tauri uses Chromium on Windows and WebKit on macOS and Linux
     target: process.env.TAURI_PLATFORM == 'windows' ? 'chrome105' : 'safari13',
     // don't minify for debug builds


### PR DESCRIPTION
Add new `-insecure-tls` option for remote locations.

Add new application args:

```
USAGE:
    restic-browser.exe [OPTIONS]

OPTIONS:
    -h, --help
            Print help information

        --insecure-tls
            skip TLS certificate verification when connecting to the repo (insecure)

        --password <password>
            password for the repository - NOT RECOMMENDED - USE password-file/command instead.
            (default: $RESTIC_PASSWORD)

        --password-command <password-command>
            shell command to obtain the repository password from (default: $RESTIC_PASSWORD_COMMAND)

        --password-file <password-file>
            file to read the repository password from (default: $RESTIC_PASSWORD_FILE)

    -r, --repo <repo>
            repository to show or restore from (default: $RESTIC_REPOSITORY)

        --repository-file <repository-file>
            file to read the repository location from (default: $RESTIC_REPOSITORY_FILE)

        --restic <restic>
            ABS path to the restic executable that should be used. (default: find in $PATH)

    -V, --version
            Print version information
```
