### PR TITLE
Feature/rclone path

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,46 @@ The UI is navigatable via keyboard shortcuts. To change the focus area, hit `Tab
 - `r`: Restore selected file or folder
 
 
+## Arguments
+
+### Usage
+```
+Restic-Browser [OPTIONS]
+```
+
+### Options
+```
+-h, --help
+    Print help information
+
+--insecure-tls
+    skip TLS certificate verification when connecting to the repo (insecure)
+
+--password <password>
+    password for the repository - NOT RECOMMENDED - USE password-file/command instead. (default: $RESTIC_PASSWORD)
+
+--password-command <password-command>
+    shell command to obtain the repository password from (default: $RESTIC_PASSWORD_COMMAND)
+  
+--password-file <password-file>
+    file to read the repository password from (default: $RESTIC_PASSWORD_FILE)
+
+-r, --repo <repo>
+    repository to show or restore from (default: $RESTIC_REPOSITORY)
+
+--rclone <rclone>
+    ABS path to the rclone executable that should be used for rclone locations. (default: 'rclone')
+
+--repository-file <repository-file>
+    file to read the repository location from (default: $RESTIC_REPOSITORY_FILE)
+
+--restic <restic>
+    ABS path to the restic executable that should be used. (default: find in $PATH)
+
+-V, --version
+    Print version information
+```
+
 ## System Requirements
 
 #### All platforms

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
       },
       "devDependencies": {
         "@tauri-apps/cli": "^1.5.2",
+        "@types/node": "^20.10.6",
         "typescript": "^5.2.2",
         "vite": "^4.4.11"
       }
@@ -655,6 +656,15 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@types/node": {
+      "version": "20.10.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.6.tgz",
+      "integrity": "sha512-Vac8H+NlRNNlAmDfGUP7b5h/KA+AtWIzuXy0E6OyP8f1tCLYAtPvKRRDJjAPqhpCb0t6U2j7/xqAuLEebW2kiw==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "node_modules/@types/trusted-types": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.4.tgz",
@@ -1171,6 +1181,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/vite": {
       "version": "4.5.1",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "@tauri-apps/cli": "^1.5.2",
+    "@types/node": "^20.10.6",
     "typescript": "^5.2.2",
     "vite": "^4.4.11"
   },

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -16,11 +16,7 @@ pub struct AppState {
 }
 
 impl AppState {
-    pub fn new(
-        restic: restic::Program,
-        location: restic::Location,
-        temp_dir: PathBuf,
-    ) -> Self {
+    pub fn new(restic: restic::Program, location: restic::Location, temp_dir: PathBuf) -> Self {
         let snapshot_ids = HashSet::default();
         Self {
             restic,
@@ -35,17 +31,17 @@ impl AppState {
     }
 
     pub fn verify_restic_path(&self) -> Result<(), String> {
-        if self.restic.path.as_os_str().is_empty() {
+        if self.restic.restic_path.as_os_str().is_empty() {
             return Err("No restic executable set".to_string());
-        } else if !self.restic.path.exists() {
+        } else if !self.restic.restic_path.exists() {
             return Err(format!(
                 "Restic executable '{}' does not exist or can not be accessed.",
-                self.restic.path.to_string_lossy()
+                self.restic.restic_path.to_string_lossy()
             ));
         } else if self.restic.version == [0, 0, 0] {
             return Err(format!(
                 "Failed to query restic version. Is '{}' a valid restic application?",
-                self.restic.path.to_string_lossy()
+                self.restic.restic_path.to_string_lossy()
             ));
         }
         Ok(())
@@ -144,7 +140,7 @@ pub fn verify_restic_path(
 ) -> Result<(), String> {
     // verify that restic binary is set
     let state = app_state.get()?;
-    if !state.restic.path.exists() {
+    if !state.restic.restic_path.exists() {
         // aks user to resolve restic path
         MessageDialogBuilder::new(
             "Restic Binary Missing",
@@ -163,7 +159,7 @@ Please select your installed restic binary manually in the following dialog.",
             restic_path.clone().unwrap_or_default().display()
         );
         if let Some(restic_path) = restic_path {
-            app_state.update_restic(restic::Program::new(restic_path))?;
+            app_state.update_restic(restic::Program::new(restic_path, state.restic.rclone_path))?;
         }
     }
     Ok(())

--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -31,17 +31,17 @@ impl AppState {
     }
 
     pub fn verify_restic_path(&self) -> Result<(), String> {
-        if self.restic.restic_path.as_os_str().is_empty() {
+        if self.restic.restic_path().as_os_str().is_empty() {
             return Err("No restic executable set".to_string());
-        } else if !self.restic.restic_path.exists() {
+        } else if !self.restic.restic_path().exists() {
             return Err(format!(
                 "Restic executable '{}' does not exist or can not be accessed.",
-                self.restic.restic_path.to_string_lossy()
+                self.restic.restic_path().to_string_lossy()
             ));
-        } else if self.restic.version == [0, 0, 0] {
+        } else if self.restic.restic_version() == [0, 0, 0] {
             return Err(format!(
                 "Failed to query restic version. Is '{}' a valid restic application?",
-                self.restic.restic_path.to_string_lossy()
+                self.restic.restic_path().to_string_lossy()
             ));
         }
         Ok(())
@@ -140,7 +140,7 @@ pub fn verify_restic_path(
 ) -> Result<(), String> {
     // verify that restic binary is set
     let state = app_state.get()?;
-    if !state.restic.restic_path.exists() {
+    if !state.restic.restic_path().exists() {
         // aks user to resolve restic path
         MessageDialogBuilder::new(
             "Restic Binary Missing",
@@ -159,7 +159,8 @@ Please select your installed restic binary manually in the following dialog.",
             restic_path.clone().unwrap_or_default().display()
         );
         if let Some(restic_path) = restic_path {
-            app_state.update_restic(restic::Program::new(restic_path, state.restic.rclone_path))?;
+            let rclone_path = state.restic.rclone_path().clone();
+            app_state.update_restic(restic::Program::new(restic_path, rclone_path))?;
         }
     }
     Ok(())

--- a/src-tauri/src/restic/command/group.rs
+++ b/src-tauri/src/restic/command/group.rs
@@ -1,0 +1,112 @@
+use std::{collections::HashMap, sync::RwLock};
+
+use lazy_static::lazy_static;
+
+// -------------------------------------------------------------------------------------------------
+
+/// Exit code a process gets killed with via kill_process_with_id.
+#[cfg(target_os = "windows")]
+pub const COMMAND_TERMINATED_EXIT_CODE: u32 = 288;
+
+/// Tries to gracefully terminate a process with the provided process ID.
+#[cfg(target_os = "windows")]
+fn terminate_process_with_id(pid: u32) -> Result<(), String> {
+    use windows_sys::Win32::{
+        Foundation::{CloseHandle, GetLastError, BOOL, FALSE, HANDLE, WIN32_ERROR},
+        System::Threading::{OpenProcess, TerminateProcess, PROCESS_TERMINATE},
+    };
+    log::info!("Killing process with PID {}", pid);
+
+    unsafe {
+        // Open the process handle with intent to terminate
+        let handle: HANDLE = OpenProcess(PROCESS_TERMINATE, FALSE, pid);
+        if handle == 0 {
+            let error: WIN32_ERROR = GetLastError();
+            return Err(format!(
+                "Failed to obtain handle to process {}: {:#x}",
+                pid, error
+            ));
+        }
+        // Terminate the process
+        let result: BOOL = TerminateProcess(handle, COMMAND_TERMINATED_EXIT_CODE);
+        // Close the handle now that its no longer needed
+        CloseHandle(handle);
+        if result == FALSE {
+            let error: WIN32_ERROR = GetLastError();
+            return Err(format!("Failed to terminate process {}: {:#x}", pid, error));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(not(target_os = "windows"))]
+fn terminate_process_with_id(pid: u32) -> Result<(), String> {
+    use nix::{
+        sys::signal::{self, Signal},
+        unistd::Pid,
+    };
+    log::info!("Killing process with PID {}", pid);
+    signal::kill(Pid::from_raw(pid as i32), Signal::SIGTERM).map_err(|err| err.to_string())
+}
+
+// -------------------------------------------------------------------------------------------------
+
+lazy_static! {
+    /// Currently running processes mapped by command group names.
+    static ref RUNNING_RESTIC_COMMANDS: RwLock<HashMap<String, Vec<u32>>> =
+        RwLock::new(HashMap::new());
+}
+
+/// Kill all running commands from the given command group.
+pub fn terminate_all_commands_in_group(command_group: &str) -> Result<(), String> {
+    let running_child_ids = {
+        if let Some(child_ids) = RUNNING_RESTIC_COMMANDS
+            .write()
+            .map_err(|err| err.to_string())?
+            .get_mut(command_group)
+        {
+            std::mem::take(child_ids)
+        } else {
+            vec![]
+        }
+    };
+    if !running_child_ids.is_empty() {
+        log::debug!(
+            "Terminating {} processes in group '{}'...",
+            running_child_ids.len(),
+            command_group
+        );
+        for child_id in running_child_ids {
+            if let Err(err) = terminate_process_with_id(child_id) {
+                log::warn!("Failed to kill command with PID {}: {}", child_id, err);
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Register the given child it with a command group.
+pub fn add_command_to_group(command_group: &str, child_id: u32) -> Result<(), String> {
+    log::debug!("Process in group '{command_group}' with PID '{child_id}' started...");
+    let mut running_child_ids = RUNNING_RESTIC_COMMANDS
+        .write()
+        .map_err(|err| err.to_string())?;
+    if let Some(child_ids) = running_child_ids.get_mut(command_group) {
+        child_ids.push(child_id);
+    } else {
+        running_child_ids.insert(command_group.to_string(), vec![child_id]);
+    }
+    Ok(())
+}
+
+// Unregister the given child from a command group.
+pub fn remove_command_from_group(command_group: &str, child_id: u32) -> Result<(), String> {
+    log::debug!("Process in group '{command_group}' with PID '{child_id}' finished");
+    let mut running_child_ids = RUNNING_RESTIC_COMMANDS
+        .write()
+        .map_err(|err| err.to_string())?;
+    if let Some(commands) = running_child_ids.get_mut(command_group) {
+        commands.retain(|id| *id != child_id);
+    }
+    Ok(())
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -60,6 +60,11 @@
           "longDescription": "ABS path to the restic executable that should be used. (default: find in $PATH)"
         },
         {
+          "name": "rclone",
+          "takesValue": true,
+          "longDescription": "ABS path to the rclone executable that should be used for rclone locations. (default: 'rclone')"
+        },
+        {
           "name": "repo",
           "short": "r",
           "takesValue": true,

--- a/src/components/app-footer.ts
+++ b/src/components/app-footer.ts
@@ -20,7 +20,7 @@ export class ResticBrowserAppFooter extends MobxLitElement {
   constructor() {
     super();
 
-    let messageTimeoutId: number | undefined = undefined;
+    let messageTimeoutId: NodeJS.Timeout | undefined = undefined;
     mobx.autorun(() => {
       let newMessage = "";
       if (appState.pendingFileDumps.length) {


### PR DESCRIPTION
- When rclone is not in PATH on macOS, try to locate it in the common path folders and pass the rclone path as option flag to restic. 

- Added an app argument option to manually set a path to the rclone executable. 

Fixes #88 