### PR TITLE
New Google Cloud Auth

### DIFF
--- a/src-tauri/src/restic.rs
+++ b/src-tauri/src/restic.rs
@@ -43,7 +43,7 @@ pub fn supported_location_types() -> Vec<LocationTypeInfo> {
             LocationType::GoogleCloudStorage,
             "gs",
             "Google Cloud Storage",
-            vec!["GOOGLE_ACCESS_TOKEN"],
+            vec!["GOOGLE_PROJECT_ID", "GOOGLE_APPLICATION_CREDENTIALS"],
         ),
     ]
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -42,6 +42,11 @@ export class ResticBrowserApp extends MobxLitElement {
        width: 100vw; 
        height: 100%;
     }
+    #error {
+       height: 100%;
+       align-items: center;
+       justify-content: center;
+    }
     #footer {
       height: auto;
     }
@@ -99,10 +104,12 @@ export class ResticBrowserApp extends MobxLitElement {
             .refreshRepositoryClick=${() => appState.openRepository() }
           >
           </restic-browser-app-header>
-          <restic-browser-error-message 
-              type=${appState.repoError ? "error" : "info"} 
-              message=${errorMessage}>
-          </restic-browser-error-message>
+          <vaadin-horizontal-layout id="error">
+            <restic-browser-error-message 
+                type=${appState.repoError ? "error" : "info"} 
+                message=${errorMessage}>
+            </restic-browser-error-message>
+          </vaadin-horizontal-layout>
         </vaadin-vertical-layout>
       `;
     }

--- a/src/components/error-message.ts
+++ b/src/components/error-message.ts
@@ -21,7 +21,9 @@ export class ResticBrowserErrorMessage extends LitElement {
 
   static styles = css`
     #layout {
+      display: flex;
       height: 100%; 
+      width: auto;
       align-items: center; 
       justify-content: center; 
       margin-bottom: 25%;

--- a/src/components/location-dialog.ts
+++ b/src/components/location-dialog.ts
@@ -86,18 +86,18 @@ export class ResticBrowserLocationDialog extends MobxLitElement {
   }
 
   static dialogStyles: CSSResultGroup = css`
-    #dialogContent { }
+    // #dialogContent { }
     #locationPresets {
       margin-right: 1rem; 
     }
-    #locationProperties { }
+    // #locationProperties { }
     #locationPropertyButtons {
       margin-top: 1rem
     }
   `;
 
   static footerStyles: CSSResultGroup = css`
-    #footerContent { }
+    // #footerContent { }
   `;
 
   render() {

--- a/src/components/location-properties.ts
+++ b/src/components/location-properties.ts
@@ -1,5 +1,5 @@
 import { CSSResultGroup, css, html, nothing } from 'lit'
-import { customElement, property  } from 'lit/decorators.js'
+import { customElement, property } from 'lit/decorators.js'
 import { MobxLitElement } from '@adobe/lit-mobx';
 import * as mobx from 'mobx';
 
@@ -8,7 +8,7 @@ import { Location } from '../states/location';
 
 import { Notification } from '@vaadin/notification';
 
-import { open } from '@tauri-apps/api/dialog';
+import { DialogFilter, open } from '@tauri-apps/api/dialog';
 import { fs } from '@tauri-apps/api';
 
 import '@vaadin/horizontal-layout';
@@ -22,26 +22,25 @@ import '@vaadin/notification';
 
 // -------------------------------------------------------------------------------------------------
 
-/**
- * Location credentials display types. Defaults to Password.
- */
-
+// Credential display types.
 enum CredentialDisplayType {
   Password,
   Text,
   File
 };
 
-const credentialDisplayTypes = new Map([
-  ["AWS_ACCESS_KEY_ID", CredentialDisplayType.Text], 
-  ["AZURE_ACCOUNT_NAME", CredentialDisplayType.Text], 
-  ["B2_ACCOUNT_ID", CredentialDisplayType.Text], 
-  ["GOOGLE_PROJECT_ID", CredentialDisplayType.Text], 
-  ["GOOGLE_APPLICATION_CREDENTIALS", CredentialDisplayType.File], 
+// Known credential display types. Defaults to "Password" when undefined.
+const credentialDisplayTypes: Map<string, CredentialDisplayType> = new Map([
+  ["AWS_ACCESS_KEY_ID", CredentialDisplayType.Text],
+  ["AZURE_ACCOUNT_NAME", CredentialDisplayType.Text],
+  ["B2_ACCOUNT_ID", CredentialDisplayType.Text],
+  ["GOOGLE_PROJECT_ID", CredentialDisplayType.Text],
+  ["GOOGLE_APPLICATION_CREDENTIALS", CredentialDisplayType.File],
 ]);
 
-const credentialFileFilters = new Map([
-  ["GOOGLE_APPLICATION_CREDENTIALS", [{name: "json", extensions: ["json"]}]]
+// Dialog file filters for known file credentials. Defaults to "All files *.*".
+const credentialFileFilters: Map<string, DialogFilter[]> = new Map([
+  ["GOOGLE_APPLICATION_CREDENTIALS", [{ name: "json", extensions: ["json"] }]]
 ]);
 
 // -------------------------------------------------------------------------------------------------
@@ -54,7 +53,7 @@ const credentialFileFilters = new Map([
 export class ResticBrowserLocationProperties extends MobxLitElement {
 
   // when false, all form fields are disabled
-  @property({type: Boolean})
+  @property({ type: Boolean })
   allowEditing: boolean = true;
 
   // get actual edited state of the location
@@ -68,7 +67,7 @@ export class ResticBrowserLocationProperties extends MobxLitElement {
   constructor() {
     super();
     mobx.makeObservable(this);
-    
+
     // initialize from app state and auto-update on changes
     mobx.autorun(() => {
       this._location.setFromOtherLocation(appState.repoLocation);
@@ -130,7 +129,7 @@ export class ResticBrowserLocationProperties extends MobxLitElement {
                 <vaadin-password-field 
                   label=${value.name}
                   required
-                  .disabled=${! this.allowEditing}
+                  .disabled=${!this.allowEditing}
                   value=${value.value}
                   @change=${mobx.action((event: CustomEvent) => {
                     value.value = (event.target as HTMLInputElement).value;
@@ -140,7 +139,7 @@ export class ResticBrowserLocationProperties extends MobxLitElement {
                 <vaadin-text-field 
                   label=${value.name}
                   required
-                  .disabled=${! this.allowEditing}
+                  .disabled=${!this.allowEditing}
                   value=${value.value}
                   @change=${mobx.action((event: CustomEvent) => {
                     value.value = (event.target as HTMLInputElement).value;
@@ -152,7 +151,7 @@ export class ResticBrowserLocationProperties extends MobxLitElement {
                     style="width: 100%; margin-right: 4px;"
                     label=${value.name}
                     required
-                    .disabled=${! this.allowEditing}
+                    .disabled=${!this.allowEditing}
                     value=${value.value}
                     @change=${mobx.action((event: CustomEvent) => {
                       value.value = (event.target as HTMLInputElement).value;
@@ -172,7 +171,7 @@ export class ResticBrowserLocationProperties extends MobxLitElement {
             style="width: 100%; margin-right: 4px;"
             label="Repository Password"
             required
-            .disabled=${! this.allowEditing}
+            .disabled=${!this.allowEditing}
             value=${this._location.password}
             @change=${mobx.action((event: CustomEvent) => {
               this._location.password = (event.target as HTMLInputElement).value;
@@ -192,7 +191,7 @@ export class ResticBrowserLocationProperties extends MobxLitElement {
                    id="checkbox" 
                    label="Insecure TLS (skip TLS certificate verifications)"
                    .checked=${this._location.insecureTls}
-                   .disabled=${! this.allowEditing}
+                   .disabled=${!this.allowEditing}
                    @change=${mobx.action((event: CustomEvent) => {
                      this._location.insecureTls = (event.target as HTMLInputElement).checked;
                    })}


### PR DESCRIPTION
Use "GOOGLE_PROJECT_ID" and "GOOGLE_APPLICATION_CREDENTIALS" instead of "GOOGLE_ACCESS_TOKEN" for google clous storage locations. 

Show credentials in location dialog as either text (ids), password (everything else) or file fields (GOOGLE_APPLICATION_CREDENTIALS).