### PR TITLE
clear RESTIC_REPOSITORY_FILE and RESTIC_PASSWORD_FILE

### DIFF
--- a/src-tauri/src/restic/command.rs
+++ b/src-tauri/src/restic/command.rs
@@ -221,9 +221,12 @@ impl Program {
             } else {
                 envs.insert("RESTIC_REPOSITORY".to_string(), location.path.clone());
             }
+            // ensure that only RESTIC_REPOSITORY is set: restic else may use the repo file
+            envs.insert("RESTIC_REPOSITORY_FILE".to_string(), "".to_string());
         }
         if !location.password.is_empty() {
             envs.insert("RESTIC_PASSWORD".to_string(), location.password.clone());
+            envs.insert("RESTIC_PASSWORD_FILE".to_string(), "".to_string());
         }
         for credential in location.credentials.clone() {
             envs.insert(credential.name, credential.value);


### PR DESCRIPTION
 in env when running the restic executable, in case they already got specified manually in the environment. Restic will fail to run when both are specified.

fixes https://github.com/emuell/restic-browser/issues/115