### PR TITLE
use crates.io for window-state plugin

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2933,7 +2933,8 @@ dependencies = [
 [[package]]
 name = "tauri-plugin-window-state"
 version = "0.1.1"
-source = "git+https://github.com/tauri-apps/plugins-workspace?branch=v1#677bade9089f2963e5858cc5062e5504787eaf7f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa47eaa4047a7b51064caff32f0c6282e2c5adc6ceacdd493ecf1b01fa4b0eaa"
 dependencies = [
  "bincode",
  "bitflags 2.6.0",
@@ -3636,7 +3637,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,7 +31,7 @@ shlex = { version = "^1.2" }
 
 # tauri
 tauri = { version = "^1.6", features = ["fs-all", "dialog-all", "cli"] }
-tauri-plugin-window-state = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
+tauri-plugin-window-state = "^0.1.1"
 fix-path-env = { git = "https://github.com/tauri-apps/fix-path-env-rs", branch = "dev" }
 
 # windows


### PR DESCRIPTION
Tauri sets the plugin “tauri-plugin-window-state” as a dependency. Unfortunately, this was not available in the central packet service crates.io at the time, so the template added it directly via git.

Unlike other dependencies like “fix-path-env-rs” it didn't get an own repo but is in a monorepo with others. Like explained in the same page by tauri (https://github.com/tauri-apps/plugins-workspace/tree/v2/plugins/window-state) this doesn't work well with some package managers. I'm affected by this, my package manager can't cache it because of this.

By now, the tauri project published it to crates.io, so the same version can be pulled from there.

tested on macOS aarch64