### PR TITLE
Console Output 

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2345,7 +2345,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-window-state",
  "which",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -38,8 +38,8 @@ fix-path-env = { git = "https://github.com/tauri-apps/fix-path-env-rs", branch =
 
 # windows
 [target.'cfg(target_os = "windows")'.dependencies.windows-sys]
-version = "^0.52"
-features = ["Win32_Foundation", "Win32_System_Threading"]
+version = "^0.59"
+features = ["Win32_Foundation", "Win32_System_Threading", "Win32_System_Console"]
 
 # posix
 [target.'cfg(not(target_os = "windows"))'.dependencies.nix]

--- a/src-tauri/src/restic/command/group.rs
+++ b/src-tauri/src/restic/command/group.rs
@@ -20,7 +20,7 @@ fn terminate_process_with_id(pid: u32) -> Result<(), String> {
     unsafe {
         // Open the process handle with intent to terminate
         let handle: HANDLE = OpenProcess(PROCESS_TERMINATE, FALSE, pid);
-        if handle == 0 {
+        if handle.is_null() {
             let error: WIN32_ERROR = GetLastError();
             return Err(format!(
                 "Failed to obtain handle to process {pid}: {error:#x}",


### PR DESCRIPTION
Try to detect if Restic Browser is running in a console. When passing -V or -h args, dump to the console and exit the app. Also exit the app when specifying invalid arguments. 

On Windows, try to attach to a console. This doesnt make the app a command line app, but at leasts shows the output in the console.