### PR TITLE
Support read-only repositories by using `--no-lock`.

### DIFF
--- a/src-tauri/src/restic/command.rs
+++ b/src-tauri/src/restic/command.rs
@@ -197,6 +197,7 @@ impl Program {
             .copied()
             .map(|s| Cow::Borrowed(OsStr::new(s)))
             .collect::<Vec<_>>();
+        args.push(Cow::Borrowed(OsStr::new("--no-lock")));
         if location.prefix.starts_with("rclone") {
             if let Some(rclone_path) = &self.rclone_path {
                 args.push(Cow::Borrowed(OsStr::new("--option")));

--- a/src-tauri/src/restic/command.rs
+++ b/src-tauri/src/restic/command.rs
@@ -197,6 +197,8 @@ impl Program {
             .copied()
             .map(|s| Cow::Borrowed(OsStr::new(s)))
             .collect::<Vec<_>>();
+        // All expected restic operations are read-only right now, so always avoid locks.
+        // This allows users to have read-only repositories.
         args.push(Cow::Borrowed(OsStr::new("--no-lock")));
         if location.prefix.starts_with("rclone") {
             if let Some(rclone_path) = &self.rclone_path {


### PR DESCRIPTION
I've added the `--no-lock` flag and everything seemed to work.

Thins I've tested:

- Opening an S3 repository
- Browsing files from a backup of the repository
- Downloading files.
- Restoring a folder

All of this seemed to work fine.

Related issue #144 