### PR TITLE
Add RESTIC_REST_USERNAME and RESTIC_REST_PASSWORD to rest server conf…

### DIFF
--- a/src-tauri/src/restic.rs
+++ b/src-tauri/src/restic.rs
@@ -19,7 +19,12 @@ pub fn supported_location_types() -> Vec<LocationTypeInfo> {
     vec![
         LocationTypeInfo::new(LocationType::Local, "", "Local Path", &[]),
         LocationTypeInfo::new(LocationType::SFtp, "sftp", "SFTP", &[]),
-        LocationTypeInfo::new(LocationType::Rest, "rest", "REST Server", &[]),
+        LocationTypeInfo::new(
+            LocationType::Rest,
+            "rest",
+            "REST Server",
+            &["RESTIC_REST_USERNAME", "RESTIC_REST_PASSWORD"]
+        ),
         LocationTypeInfo::new(LocationType::RClone, "rclone", "RCLONE", &[]),
         LocationTypeInfo::new(
             LocationType::AmazonS3,

--- a/src/components/location-properties.ts
+++ b/src/components/location-properties.ts
@@ -36,6 +36,7 @@ const credentialDisplayTypes: Map<string, CredentialDisplayType> = new Map([
   ["B2_ACCOUNT_ID", CredentialDisplayType.Text],
   ["GOOGLE_PROJECT_ID", CredentialDisplayType.Text],
   ["GOOGLE_APPLICATION_CREDENTIALS", CredentialDisplayType.File],
+  ["RESTIC_REST_USERNAME", CredentialDisplayType.Text],
 ]);
 
 // Dialog file filters for known file credentials. Defaults to "All files *.*".


### PR DESCRIPTION
Add `RESTIC_REST_USERNAME` and `RESTIC_REST_PASSWORD` to rest server configuration.

Without providing `REST_REST_*` restic-browser gets 401 unauthorized error if rest-server is protected with `.htpasswd`.
https://restic.readthedocs.io/en/latest/030_preparing_a_new_repo.html#rest-server